### PR TITLE
check if role has a name

### DIFF
--- a/lib/canner/policy.rb
+++ b/lib/canner/policy.rb
@@ -49,9 +49,12 @@ module Canner
 
     def has_role?(roles)
       begin
-        @roles.any?{|r| Util.prepare(roles).include?(r.name.to_sym) }
+        @roles.any? do |r|
+          name = r.respond_to?(:name) ? r.name : r.to_s
+          Util.prepare(roles).include?(name.to_sym)
+        end
       rescue Exception => e
-        raise ArgumentError.new "Canner: Problem fetching user roles. If current_user.roles isn't how you do it see wiki for overriding fetch_roles."
+        raise ArgumentError.new "Canner: Problem fetching user roles. If current_user.roles isn't how you do it see wiki for overriding fetch_roles. #{e}"
       end
     end
 

--- a/lib/canner/util.rb
+++ b/lib/canner/util.rb
@@ -3,7 +3,7 @@ class Util
   # ensures whatever is passed in comes out an array of symbols
   class << self
     def prepare(str)
-      symbolize(arrayify(str))
+      symbolize(arrayify(str).flatten)
     end
 
     # ensures the array elements are symbols
@@ -13,9 +13,13 @@ class Util
 
     # ensure given roles are in the form of an array
     def arrayify(roles)
-      Array.wrap(roles).flatten
+      if roles.nil?
+        []
+      elsif roles.respond_to?(:to_ary)
+        roles.to_ary || [roles]
+      else
+        [roles]
+      end
     end
-
   end
-
 end

--- a/lib/canner/util.rb
+++ b/lib/canner/util.rb
@@ -3,23 +3,7 @@ class Util
   # ensures whatever is passed in comes out an array of symbols
   class << self
     def prepare(str)
-      symbolize(arrayify(str).flatten)
-    end
-
-    # ensures the array elements are symbols
-    def symbolize(strings)
-      strings.map{|s| s.to_sym}
-    end
-
-    # ensure given roles are in the form of an array
-    def arrayify(roles)
-      if roles.nil?
-        []
-      elsif roles.respond_to?(:to_ary)
-        roles.to_ary || [roles]
-      else
-        [roles]
-      end
+      Array(str).flatten.map(&:to_sym)
     end
   end
 end

--- a/spec/canner_spec.rb
+++ b/spec/canner_spec.rb
@@ -4,7 +4,7 @@ require "canner"
 class Sample
 end
 
-class SamplePolicy
+class SamplePolicy < Canner::Policy
 
   def initialize(current_user, method, current_branch)
     @current_user = current_user
@@ -14,13 +14,21 @@ class SamplePolicy
   end
 
   def fetch_roles
-    # ['admin']
+    ['admin']
   end
 
   def canner_scope
-    # [Sample.new]
+    [Sample.new]
   end
 
+  def can?
+   case @method
+   when :index, :show
+     has_role?(:admin)
+   else
+     false
+   end
+  end
 end
 
 class AppController


### PR DESCRIPTION
I noticed that has_role? assumed you had a name instance method on a role. It looks like the docs assume fetch_roles returns an array of symbols/strings. When trying it out I couldn't things to work for me (it was calling r.name when r was a string), so I added a few things.

I've also went through and removed Array.wrap. I couldn't get the tests to pass without it. I think this is an ActiveSupport extension, so I've just lifted it from there. 
