### PR TITLE
Remove devise specifics

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,10 +237,17 @@ You are able to force the use of controller authorization with canner.
 I recommend you do this so you don't forget to wrap authorization about some of your resources.
 
 To make sure your controller actions are using the can? method add this near the top of your
-application_controller.rb
+`application_controller.rb`.  Use the `except:` option for ensuring we ignore controllers
+related to authentication.
 
 ``` ruby
 after_action :ensure_auth
+
+# using devise?
+after_action :ensure_auth, except: :devise_controller?
+
+# using CASino?
+after_action :ensure_auth, except: -> { self.is_a? CASino::ApplicationController }
 ```
 
 And to make sure you are using the canner_scope do the following:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ need to override the fetch_roles policy method.
 rails g canner:fetch_roles
 ```
 
-More details are available in the wiki: 
+More details are available in the wiki:
 [Overriding the Fetching of Roles](https://github.com/jacklin10/canner/wiki/Feed-Roles)
 
 ## Policies
@@ -64,7 +64,7 @@ As mentioned Canner is strongly influenced by Pundit and is also based on Policy
 Your policy objects should be named using the following pattern:   
 UserPolicy, CustomerPolicy, AppPolicy.
 
-Use the generator to save you some time: 
+Use the generator to save you some time:
 ``` rails g canner:policy <model name> ```
 
 Your policy models need to implement 2 methods:
@@ -167,7 +167,7 @@ end
 
 in your base_policy's `can?` method
 
-### instance_can? 
+### instance_can?
 
 You use the instance_can? method to determine if the current_user is able to modify a particular instance
 of an object.  
@@ -180,13 +180,13 @@ For example, if a user who belongs to company A wants to edit a particular item 
 
 Normal stuff.  The user changes the item price and moves on.  
 
-But now we have another user who decides they want to see what happens when they manually change the url: 
+But now we have another user who decides they want to see what happens when they manually change the url:
 
 ```
 /items/13/edit
 ```
 
-If you don't defend against this the user would be granted access to edit item with id=13 which 
+If you don't defend against this the user would be granted access to edit item with id=13 which
 belongs to a different company.  
 
 The instance_can? method helps in these situations.  
@@ -258,7 +258,7 @@ after_action :ensure_scope, only: :index
 Note the use of only here.  You usually won't need the canner_scope on anything except
 for the index to be strictly enforced.
 
-And finally, if you want to enforce that you are using instance_can? use something like: 
+And finally, if you want to enforce that you are using instance_can? use something like:
 ``` ruby
 after_action :ensure_instance_checking, only: [:edit, :destroy, :update]
 ```

--- a/lib/canner.rb
+++ b/lib/canner.rb
@@ -74,19 +74,16 @@ module Canner
   protected
 
   def ensure_scope
-    return if devise_controller? rescue false
     raise ScopeNotUsedError.new("Must use a canner_scope or exclude this action from the after_action") unless scope_used
     true
   end
 
   def ensure_auth
-    return if devise_controller? rescue false
     raise AuthNotUsedError.new("Must use can? method or exclude this action from the after_action") unless auth_used
     true
   end
 
   def ensure_instance_checking
-    return if devise_controller? rescue false
     raise AuthNotUsedError.new("Must use instance_can? method or exclude this action from the after_action") unless instance_checked
     true
   end


### PR DESCRIPTION
Canner right now has knowledge of devise.  It also does not depend on it.  Rails helper has the ability for the host project to decide when to activate canner.  This also adds performance hits for non-devise based applications.  Also their may be cases where people want canner in place for specific devise[d] entities / controllers.
